### PR TITLE
Handle `Packet::None`, update deps & optimize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flatbuffers = { git = "https://github.com/google/flatbuffers", rev = "129ef422" }
-glam = { version = "0.25.0", optional = true }
+flatbuffers = "24.3.25"
+glam = { version = "0.27.0", optional = true }
 thiserror = "1.0.50"
 
 [features]

--- a/examples/atba_agent.rs
+++ b/examples/atba_agent.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, f32::consts::PI};
 
 use rlbot_interface::{
     agents::{run_agent, Agent},
@@ -32,11 +32,11 @@ impl Agent for AtbaAgent {
 
         let mut bot_front_to_target_angle = bot_to_target_angle - car.rotation.yaw;
 
-        if bot_front_to_target_angle > 3.14 {
-            bot_front_to_target_angle -= 2. * 3.14
+        if bot_front_to_target_angle > PI {
+            bot_front_to_target_angle -= 2. * PI
         };
-        if bot_front_to_target_angle < -3.14 {
-            bot_front_to_target_angle += 2. * 3.14
+        if bot_front_to_target_angle < -PI {
+            bot_front_to_target_angle += 2. * PI
         };
 
         let mut controller = ControllerState::default();

--- a/examples/atba_raw.rs
+++ b/examples/atba_raw.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, f32::consts::PI};
 
 use rlbot_interface::{
     rlbot::{ControllerState, PlayerInput, ReadyMessage},
@@ -45,11 +45,11 @@ fn main() {
 
         let mut bot_front_to_target_angle = bot_to_target_angle - car.rotation.yaw;
 
-        if bot_front_to_target_angle > 3.14 {
-            bot_front_to_target_angle -= 2. * 3.14
+        if bot_front_to_target_angle > PI {
+            bot_front_to_target_angle -= 2. * PI
         };
-        if bot_front_to_target_angle < -3.14 {
-            bot_front_to_target_angle += 2. * 3.14
+        if bot_front_to_target_angle < -PI {
+            bot_front_to_target_angle += 2. * PI
         };
 
         let mut controller = ControllerState::default();

--- a/examples/start_match.rs
+++ b/examples/start_match.rs
@@ -1,7 +1,7 @@
 use rlbot_interface::{
     rlbot::{
-        ExistingMatchBehavior, GameMode, Human, LoadoutPaint, MatchLength, MatchSettings,
-        MutatorSettings, PlayerClass, PlayerConfiguration, PlayerLoadout, RLBot,
+        ExistingMatchBehavior, GameMode, Human, MatchLength, MatchSettings, MutatorSettings,
+        PlayerClass, PlayerConfiguration, PlayerLoadout, RLBot,
     },
     Packet, RLBotConnection,
 };
@@ -20,7 +20,7 @@ fn main() {
                 name: "BOT1".to_owned(),
                 team: 0,
                 loadout: Some(Box::new(PlayerLoadout {
-                    loadout_paint: Some(Box::new(LoadoutPaint::default())),
+                    loadout_paint: Some(Box::default()),
                     ..Default::default()
                 })),
                 spawn_id: 0,

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -29,12 +29,12 @@ pub fn run_agent<T: Agent>(
     }))?;
 
     loop {
-        let packet = match connection.recv_packet() {
-            Ok(packet) => packet,
-            Err(e) => Err(e)?,
-        };
+        let packet = connection.recv_packet()?;
 
         match packet {
+            Packet::None => {
+                break;
+            }
             Packet::GameTickPacket(x) => {
                 let controller_state = bot.tick(x, &mut connection);
                 connection.send_packet(Packet::PlayerInput(PlayerInput {
@@ -51,5 +51,5 @@ pub fn run_agent<T: Agent>(
         }
     }
 
-    // Ok(())
+    Ok(())
 }


### PR DESCRIPTION
- Handle `Packet::None`
- Update Flatbuffers to use the new version on crates.io (finally works)
- Update glam
- Avoid excessive allocations in RLBotConnection
- Minor clippy stuff