### PR TITLE
Minor Updates

### DIFF
--- a/rlbot/src/render.rs
+++ b/rlbot/src/render.rs
@@ -101,7 +101,6 @@ impl Renderer {
 
     /// Draws text in 2d space.
     /// X and y uses screen-space coordinates, i.e. 0.1 is 10% of the screen width/height.
-    /// Use `set_resolution` to change to pixel coordinates.
     /// Characters of the font are 20 pixels tall and 10 pixels wide when `scale == 1.0`.
     /// Consider using [push] and `..default()` when using multiple default values.
     pub fn string_2d(
@@ -159,7 +158,6 @@ impl Renderer {
 
     /// Draws a rectangle anchored in 2d space.
     /// X, y, width, and height uses screen-space coordinates, i.e. 0.1 is 10% of the screen width/height.
-    /// Use `set_resolution` to change to pixel coordinates.
     /// Consider using [push] and `..default()` when using multiple default values.
     pub fn rect_2d(
         &mut self,
@@ -187,7 +185,6 @@ impl Renderer {
 
     /// Draws a rectangle anchored in 3d space.
     /// Width and height are screen-space sizes, i.e. 0.1 is 10% of the screen width/height.
-    /// Use `set_resolution` to change to pixel coordinates.
     /// The size does not change based on distance to the camera.
     /// Consider using [push] and `..default()` when using multiple default values.
     pub fn rect_3d(

--- a/rlbot_flat/Cargo.toml
+++ b/rlbot_flat/Cargo.toml
@@ -7,14 +7,14 @@ license-file.workspace = true
 [dependencies]
 planus = { git = "https://github.com/swz-git/planus", rev = "a0b1fbf" }
 serde = { version = "1.0.210", features = ["derive"] }
-glam = { version = "0.30.0", optional = true }
+glam = { version = "0.32.0", optional = true }
 
 [build-dependencies]
 planus-translation = { git = "https://github.com/swz-git/planus", rev = "a0b1fbf" }
 planus-codegen = { git = "https://github.com/swz-git/planus", rev = "a0b1fbf" }
 planus-types = { git = "https://github.com/swz-git/planus", rev = "a0b1fbf" }
 eyre = "0.6.12"
-fluent-uri = "0.3.2"
+fluent-uri = "0.4.1"
 
 [features]
 default = ["glam"]

--- a/rlbot_flat/src/lib.rs
+++ b/rlbot_flat/src/lib.rs
@@ -102,3 +102,21 @@ impl From<flat::BallAnchor> for flat::RelativeAnchor {
         flat::RelativeAnchor::BallAnchor(Box::new(value))
     }
 }
+
+impl From<flat::CarAnchor> for flat::RenderAnchor {
+    fn from(value: flat::CarAnchor) -> Self {
+        Self {
+            world: flat::Vector3::default(),
+            relative: Some(value.into()),
+        }
+    }
+}
+
+impl From<flat::BallAnchor> for flat::RenderAnchor {
+    fn from(value: flat::BallAnchor) -> Self {
+        Self {
+            world: flat::Vector3::default(),
+            relative: Some(value.into()),
+        }
+    }
+}


### PR DESCRIPTION
- Update glam to 0.32.0 from 0.30.0
- Update fluent-uri to 0.4.1 from 0.3.2
- Correct some doc comments on a few render functions
- Impl from `CarAnchor`/`BallAnchor` directly into `RenderAnchor`
  - This is from my personal wishlist, Python interface has this and I would really like it when developing my bot

Opened Rot to work on it and noticed these things when I started updating stuff